### PR TITLE
upgrade  xml2json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/ryurock/hubot-weather-ja/issues"
   },
   "dependencies": {
-    "xml2json": "~0.4.0",
+    "xml2json": "~0.6.0",
     "async": "~0.7.0",
     "date-utils": "~1.2.15"
   }


### PR DESCRIPTION
nodeのversionが0.12になると、xml2jsonでnode-gyp rebuildが失敗するのでxml2jsonのバージョンを上げました。

https://travis-ci.org/node-xmpp/node-expat/jobs/53346154
